### PR TITLE
Альтернативное скачивание NuGet-пакетов через Client API

### DIFF
--- a/Backend/PackageDownloader.Application/DiExtension.cs
+++ b/Backend/PackageDownloader.Application/DiExtension.cs
@@ -23,7 +23,7 @@ namespace PackageDownloader.Application
             return packageType switch
             {
                 PackageType.Npm => serviceProvider.GetRequiredService<NpmPackageDownloaderService>(),
-                PackageType.Nuget => serviceProvider.GetRequiredService<NugetPackageDownloaderService>(),
+                PackageType.Nuget => serviceProvider.GetRequiredService<NugetClientPackageDownloaderService>(),
                 PackageType.VsCode => serviceProvider.GetRequiredService<HttpPackageDownloaderService>(),
                 PackageType.Docker => serviceProvider.GetRequiredService<DockerPackageDownloaderService>(),
                 _ => throw new InvalidOperationException()
@@ -90,6 +90,7 @@ namespace PackageDownloader.Application
             // Package download services
 
             services.AddTransient<NugetPackageDownloaderService>();
+            services.AddTransient<NugetClientPackageDownloaderService>();
             services.AddTransient<NpmPackageDownloaderService>();
             services.AddTransient<DockerPackageDownloaderService>();
 

--- a/Backend/PackageDownloader.Infrastructure/PackageDownloader.Infrastructure.csproj
+++ b/Backend/PackageDownloader.Infrastructure/PackageDownloader.Infrastructure.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <PackageReference Include="JsonCons.JsonPath" Version="1.1.0" />
     <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
+    <PackageReference Include="NuGet.Resolver" Version="7.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Backend/PackageDownloader.Infrastructure/PackageDownloader.Infrastructure.csproj
+++ b/Backend/PackageDownloader.Infrastructure/PackageDownloader.Infrastructure.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="JsonCons.JsonPath" Version="1.1.0" />
+    <PackageReference Include="NuGet.Protocol" Version="7.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageDownloader/NugetClientPackageDownloaderService.cs
+++ b/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageDownloader/NugetClientPackageDownloaderService.cs
@@ -1,0 +1,167 @@
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using PackageDownloader.Core.Models;
+using PackageDownloader.Core.Services.Abstractions;
+using PackageDownloader.Infrastructure.Services.Abstractions;
+
+namespace PackageDownloader.Infrastructure.Services.Implementations.PackageDownloader;
+
+/// <summary>
+/// Downloads NuGet package archives through the NuGet Client SDK.
+/// </summary>
+public sealed class NugetClientPackageDownloaderService : IPackageDownloadService
+{
+    private readonly IPackagesDirectoryCreator _packagesDirectoryCreator;
+    private readonly IArchiveService _archiveService;
+    private readonly IReadOnlyList<SourceRepository> _sourceRepositories;
+
+    public NugetClientPackageDownloaderService(
+        IPackagesDirectoryCreator packagesDirectoryCreator,
+        IArchiveService archiveService)
+    {
+        _packagesDirectoryCreator = packagesDirectoryCreator;
+        _archiveService = archiveService;
+
+        ISettings settings = Settings.LoadDefaultSettings(root: null);
+        var packageSourceProvider = new PackageSourceProvider(settings);
+        var repositoryProvider = new SourceRepositoryProvider(
+            packageSourceProvider,
+            Repository.Provider.GetCoreV3());
+
+        _sourceRepositories = repositoryProvider.GetRepositories().ToArray();
+    }
+
+    public string DownloadPackagesAsArchive(PackageRequest packageRequest)
+    {
+        ArgumentNullException.ThrowIfNull(packageRequest);
+
+        return DownloadPackagesAsArchiveAsync(packageRequest, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    private async Task<string> DownloadPackagesAsArchiveAsync(
+        PackageRequest packageRequest,
+        CancellationToken cancellationToken)
+    {
+        (string tempFolderPath, string packagesDirectory) =
+            _packagesDirectoryCreator.CreatePackagesTempDirectory(packageRequest);
+
+        using var cacheContext = new SourceCacheContext();
+        var downloadedPackages = new HashSet<PackageIdentity>(PackageIdentityComparer.Default);
+
+        foreach (PackageDetails packageDetails in packageRequest.PackagesDetails)
+        {
+            PackageIdentity package = await ResolvePackageAsync(
+                packageDetails,
+                cacheContext,
+                cancellationToken);
+
+            if (!downloadedPackages.Add(package))
+                continue;
+
+            await DownloadPackageAsync(
+                package,
+                packagesDirectory,
+                cacheContext,
+                cancellationToken);
+        }
+
+        return _archiveService.ArchiveFolder(packagesDirectory, tempFolderPath);
+    }
+
+    private async Task<PackageIdentity> ResolvePackageAsync(
+        PackageDetails packageDetails,
+        SourceCacheContext cacheContext,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(packageDetails.PackageID))
+            throw new ArgumentException("NuGet package ID cannot be empty.", nameof(packageDetails));
+
+        if (!string.IsNullOrWhiteSpace(packageDetails.PackageVersion))
+        {
+            if (!NuGetVersion.TryParse(packageDetails.PackageVersion, out NuGetVersion? parsedVersion))
+            {
+                throw new ArgumentException(
+                    $"'{packageDetails.PackageVersion}' is not a valid NuGet version.",
+                    nameof(packageDetails));
+            }
+
+            return new PackageIdentity(packageDetails.PackageID, parsedVersion);
+        }
+
+        NuGetVersion? latestVersion = null;
+
+        foreach (SourceRepository repository in _sourceRepositories)
+        {
+            FindPackageByIdResource resource =
+                await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
+            IEnumerable<NuGetVersion> versions = await resource.GetAllVersionsAsync(
+                packageDetails.PackageID,
+                cacheContext,
+                NullLogger.Instance,
+                cancellationToken);
+
+            NuGetVersion? latestStableVersion = versions
+                .Where(version => !version.IsPrerelease)
+                .OrderByDescending(version => version)
+                .FirstOrDefault();
+
+            if (latestStableVersion is not null &&
+                (latestVersion is null || latestStableVersion > latestVersion))
+            {
+                latestVersion = latestStableVersion;
+            }
+        }
+
+        return latestVersion is null
+            ? throw new InvalidOperationException(
+                $"NuGet package '{packageDetails.PackageID}' was not found in configured sources.")
+            : new PackageIdentity(packageDetails.PackageID, latestVersion);
+    }
+
+    private async Task DownloadPackageAsync(
+        PackageIdentity package,
+        string destinationDirectory,
+        SourceCacheContext cacheContext,
+        CancellationToken cancellationToken)
+    {
+        string fileName = $"{package.Id}.{package.Version.ToNormalizedString()}.nupkg";
+        string destinationPath = Path.Combine(destinationDirectory, fileName);
+
+        foreach (SourceRepository repository in _sourceRepositories)
+        {
+            FindPackageByIdResource resource =
+                await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
+
+            await using var packageStream = new FileStream(
+                destinationPath,
+                FileMode.Create,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 81920,
+                useAsync: true);
+
+            bool downloaded = await resource.CopyNupkgToStreamAsync(
+                package.Id,
+                package.Version,
+                packageStream,
+                cacheContext,
+                NullLogger.Instance,
+                cancellationToken);
+
+            if (downloaded)
+                return;
+
+            packageStream.Close();
+            File.Delete(destinationPath);
+        }
+
+        throw new InvalidOperationException(
+            $"NuGet package '{package.Id}' version '{package.Version}' was not found in configured sources.");
+    }
+}

--- a/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageDownloader/NugetClientPackageDownloaderService.cs
+++ b/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageDownloader/NugetClientPackageDownloaderService.cs
@@ -1,8 +1,11 @@
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
+using NuGet.Resolver;
 using NuGet.Versioning;
 using PackageDownloader.Core.Models;
 using PackageDownloader.Core.Services.Abstractions;
@@ -52,7 +55,10 @@ public sealed class NugetClientPackageDownloaderService : IPackageDownloadServic
             _packagesDirectoryCreator.CreatePackagesTempDirectory(packageRequest);
 
         using var cacheContext = new SourceCacheContext();
-        var downloadedPackages = new HashSet<PackageIdentity>(PackageIdentityComparer.Default);
+        NuGetFramework targetFramework = ResolveTargetFramework(packageRequest.SdkVersion);
+        var rootPackages = new List<PackageIdentity>();
+        var availablePackages = new HashSet<SourcePackageDependencyInfo>(PackageIdentityComparer.Default);
+        var visitedPackages = new HashSet<PackageIdentity>(PackageIdentityComparer.Default);
 
         foreach (PackageDetails packageDetails in packageRequest.PackagesDetails)
         {
@@ -61,9 +67,23 @@ public sealed class NugetClientPackageDownloaderService : IPackageDownloadServic
                 cacheContext,
                 cancellationToken);
 
-            if (!downloadedPackages.Add(package))
-                continue;
+            rootPackages.Add(package);
+            await GatherPackageGraphAsync(
+                package,
+                targetFramework,
+                cacheContext,
+                availablePackages,
+                visitedPackages,
+                cancellationToken);
+        }
 
+        IEnumerable<PackageIdentity> resolvedPackages = ResolvePackageGraph(
+            rootPackages,
+            availablePackages,
+            cancellationToken);
+
+        foreach (PackageIdentity package in resolvedPackages)
+        {
             await DownloadPackageAsync(
                 package,
                 packagesDirectory,
@@ -72,6 +92,128 @@ public sealed class NugetClientPackageDownloaderService : IPackageDownloadServic
         }
 
         return _archiveService.ArchiveFolder(packagesDirectory, tempFolderPath);
+    }
+
+    private static NuGetFramework ResolveTargetFramework(string? sdkVersion)
+    {
+        NuGetFramework fallbackFramework = NuGetFramework.ParseFolder(DotnetFrameworks.NetStandart20);
+
+        if (string.IsNullOrWhiteSpace(sdkVersion))
+            return fallbackFramework;
+
+        NuGetFramework framework = NuGetFramework.ParseFolder(sdkVersion);
+        return framework.IsUnsupported ? fallbackFramework : framework;
+    }
+
+    private async Task GatherPackageGraphAsync(
+        PackageIdentity package,
+        NuGetFramework targetFramework,
+        SourceCacheContext cacheContext,
+        ISet<SourcePackageDependencyInfo> availablePackages,
+        ISet<PackageIdentity> visitedPackages,
+        CancellationToken cancellationToken)
+    {
+        if (!visitedPackages.Add(package))
+            return;
+
+        SourcePackageDependencyInfo? dependencyInfo = null;
+
+        foreach (SourceRepository repository in _sourceRepositories)
+        {
+            DependencyInfoResource resource =
+                await repository.GetResourceAsync<DependencyInfoResource>(cancellationToken);
+            dependencyInfo = await resource.ResolvePackage(
+                package,
+                targetFramework,
+                cacheContext,
+                NullLogger.Instance,
+                cancellationToken);
+
+            if (dependencyInfo is not null)
+                break;
+        }
+
+        if (dependencyInfo is null)
+        {
+            throw new InvalidOperationException(
+                $"NuGet package '{package.Id}' version '{package.Version}' was not found " +
+                $"for target framework '{targetFramework.GetShortFolderName()}'.");
+        }
+
+        availablePackages.Add(dependencyInfo);
+
+        foreach (PackageDependency dependency in dependencyInfo.Dependencies)
+        {
+            PackageIdentity dependencyPackage = await ResolveDependencyAsync(
+                dependency,
+                cacheContext,
+                cancellationToken);
+
+            await GatherPackageGraphAsync(
+                dependencyPackage,
+                targetFramework,
+                cacheContext,
+                availablePackages,
+                visitedPackages,
+                cancellationToken);
+        }
+    }
+
+    private async Task<PackageIdentity> ResolveDependencyAsync(
+        PackageDependency dependency,
+        SourceCacheContext cacheContext,
+        CancellationToken cancellationToken)
+    {
+        var versions = new HashSet<NuGetVersion>();
+
+        foreach (SourceRepository repository in _sourceRepositories)
+        {
+            FindPackageByIdResource resource =
+                await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
+            IEnumerable<NuGetVersion> sourceVersions = await resource.GetAllVersionsAsync(
+                dependency.Id,
+                cacheContext,
+                NullLogger.Instance,
+                cancellationToken);
+
+            versions.UnionWith(sourceVersions);
+        }
+
+        NuGetVersion? resolvedVersion = dependency.VersionRange.FindBestMatch(
+            versions.OrderBy(version => version));
+
+        return resolvedVersion is null
+            ? throw new InvalidOperationException(
+                $"Dependency '{dependency.Id}' matching range '{dependency.VersionRange}' " +
+                "was not found in configured NuGet sources.")
+            : new PackageIdentity(dependency.Id, resolvedVersion);
+    }
+
+    private IEnumerable<PackageIdentity> ResolvePackageGraph(
+        IReadOnlyCollection<PackageIdentity> rootPackages,
+        IReadOnlyCollection<SourcePackageDependencyInfo> availablePackages,
+        CancellationToken cancellationToken)
+    {
+        string[] rootPackageIds = rootPackages
+            .Select(package => package.Id)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var resolverContext = new PackageResolverContext(
+            DependencyBehavior.Lowest,
+            rootPackageIds,
+            rootPackageIds,
+            Enumerable.Empty<PackageReference>(),
+            rootPackages,
+            availablePackages,
+            _sourceRepositories.Select(repository => repository.PackageSource),
+            NullLogger.Instance);
+
+        return new PackageResolver()
+            .Resolve(resolverContext, cancellationToken)
+            .OrderBy(package => package.Id, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(package => package.Version)
+            .ToArray();
     }
 
     private async Task<PackageIdentity> ResolvePackageAsync(

--- a/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageDownloader/NugetClientPackageDownloaderService.cs
+++ b/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageDownloader/NugetClientPackageDownloaderService.cs
@@ -101,7 +101,15 @@ public sealed class NugetClientPackageDownloaderService : IPackageDownloadServic
         if (string.IsNullOrWhiteSpace(sdkVersion))
             return fallbackFramework;
 
-        NuGetFramework framework = NuGetFramework.ParseFolder(sdkVersion);
+        string targetFramework = sdkVersion.Trim();
+
+        if (char.IsDigit(targetFramework[0]) &&
+            NuGetVersion.TryParse(targetFramework, out NuGetVersion? parsedSdkVersion))
+        {
+            targetFramework = $"net{parsedSdkVersion.Major}.{parsedSdkVersion.Minor}";
+        }
+
+        NuGetFramework framework = NuGetFramework.ParseFolder(targetFramework);
         return framework.IsUnsupported ? fallbackFramework : framework;
     }
 


### PR DESCRIPTION
# Альтернативное скачивание NuGet-пакетов через Client API

## Что изменено

- Добавлен `NugetClientPackageDownloaderService`, использующий официальный NuGet Client API вместо вызова `dotnet add package`.
- Существующий `NugetPackageDownloaderService` с CLI-реализацией сохранён без изменений.
- Для `PackageType.Nuget` DI-фабрика теперь выбирает новую реализацию.
- Источники пакетов загружаются из стандартной конфигурации `NuGet.Config`, поэтому поддерживаются как nuget.org, так и настроенные внешние feeds.
- Если версия пакета не указана, выбирается последняя стабильная версия из доступных источников.
- Добавлено разрешение полного графа транзитивных зависимостей для целевой версии .NET.
- Конфликты версий в графе разрешаются с помощью `NuGet.Resolver` и стратегии `DependencyBehavior.Lowest`.
- Все разрешённые пакеты скачиваются в формате `.nupkg` и возвращаются в одном ZIP-архиве.

## Целевая версия .NET

Целевой framework определяется по `PackageRequest.SdkVersion`.

Поддерживаются оба формата:

- TFM: `net8.0`, `net10.0`;
- версия SDK: `8.0`, `10.0`, `10.0.100` — автоматически преобразуется в соответствующий TFM.

Если `SdkVersion` отсутствует или не распознаётся, используется `netstandard2.0`, что сохраняет fallback-поведение прежней реализации.

## Изменения зависимостей

В `PackageDownloader.Infrastructure` добавлены:

- `NuGet.Protocol` 7.6.0 — работа с NuGet feeds, метаданными и загрузкой `.nupkg`;
- `NuGet.Resolver` 7.6.0 — разрешение итогового набора версий пакетов.

## Пример запроса

```bash
curl -X POST \
  'http://localhost:5093/api/Packages/PreparePackagesDownloadLink' \
  -H 'accept: text/plain' \
  -H 'Content-Type: application/json' \
  -d '{
    "packageType": "Nuget",
    "sdkVersion": "10.0",
    "packagesDetails": [
      {
        "packageID": "Microsoft.EntityFrameworkCore.Sqlite",
        "packageVersion": "10.0.10"
      }
    ]
  }'
```

Для этого запроса в архив включаются корневой пакет и 21 транзитивная зависимость — всего 22 `.nupkg` файла.

## Проверка

- `dotnet build PackageDownloader.sln --configuration Release` — успешно, без ошибок и предупреждений.
- Интеграционная проверка `Microsoft.Extensions.Hosting 8.0.0` для `net8.0` — скачан граф из 31 пакета.
- Интеграционная проверка `Microsoft.EntityFrameworkCore.Sqlite 10.0.10` с `SdkVersion: 10.0` — скачаны 22 пакета, включая:
  - `Microsoft.EntityFrameworkCore.Sqlite.Core`;
  - `Microsoft.Data.Sqlite.Core`;
  - зависимости `SQLitePCLRaw`;
  - необходимые пакеты `Microsoft.Extensions`.

## Совместимость

- Публичный контракт `IPackageDownloadService` не изменён.
- Формат HTTP-запроса и ответа не изменён.
- Старая CLI-реализация остаётся в проекте и DI-контейнере, но не выбирается фабрикой для `PackageType.Nuget`.
