### PR TITLE
Добавлено получение версий пакета и ленивая загрузка списка версий

### DIFF
--- a/Backend/PackageDownloader.API/Controllers/PackageInfoController.cs
+++ b/Backend/PackageDownloader.API/Controllers/PackageInfoController.cs
@@ -26,5 +26,14 @@ namespace PackageDownloader.API.Controllers
             var packageSearchService = serviceAccessor(packageType);
             return await packageSearchService.GetPackagesNamesSuggestions(namePart);
         }
+
+        [HttpGet("[action]")]
+        [Produces("application/json")]
+        public async Task<IEnumerable<PackageVersion>> GetPackageVersions([FromQuery] PackageType packageType,
+            [FromQuery] string packageName, [FromQuery] int maxVersionsCount = 40)
+        {
+            var packageSearchService = serviceAccessor(packageType);
+            return await packageSearchService.GetPackageVersions(packageName, maxVersionsCount);
+        }
     }
 }

--- a/Backend/PackageDownloader.Core/Services/Abstractions/IPackageSearchService.cs
+++ b/Backend/PackageDownloader.Core/Services/Abstractions/IPackageSearchService.cs
@@ -7,5 +7,7 @@ namespace PackageDownloader.Core.Services.Abstractions
         Task<IEnumerable<PackageInfo>> SearchPackagesByName(string namePart);
 
         Task<IEnumerable<string>> GetPackagesNamesSuggestions(string namePart);
+        
+        Task<IEnumerable<PackageVersion>> GetPackageVersions(string packageName, int maxVersionsCount);
     }
 }

--- a/Backend/PackageDownloader.Core/Services/Abstractions/PackageVersion.cs
+++ b/Backend/PackageDownloader.Core/Services/Abstractions/PackageVersion.cs
@@ -1,0 +1,3 @@
+﻿namespace PackageDownloader.Core.Services.Abstractions;
+
+public record PackageVersion(string VersionTag, DateTime? ReleaseDate);

--- a/Backend/PackageDownloader.Infrastructure/Services/Abstractions/IJsonPathExecutor.cs
+++ b/Backend/PackageDownloader.Infrastructure/Services/Abstractions/IJsonPathExecutor.cs
@@ -8,4 +8,6 @@ public interface IJsonPathExecutor
     
     JsonElement? GetSingleNode(JsonElement rootElement, string jsonPath);
     
+    JsonElement GetRequiredSingleNode(JsonElement rootElement, string jsonPath);
+    
 }

--- a/Backend/PackageDownloader.Infrastructure/Services/Abstractions/IPackageInfoConverterService.cs
+++ b/Backend/PackageDownloader.Infrastructure/Services/Abstractions/IPackageInfoConverterService.cs
@@ -1,5 +1,6 @@
 ﻿using PackageDownloader.Core.Models;
 using System.Text.Json;
+using PackageDownloader.Core.Services.Abstractions;
 
 namespace PackageDownloader.Infrastructure.Services.Abstractions
 {
@@ -14,7 +15,10 @@ namespace PackageDownloader.Infrastructure.Services.Abstractions
         IEnumerable<string> ConvertNpmJsonToSuggestionsList(JsonDocument json);
 
         IEnumerable<string> ConvertNugetJsonToSuggestionsList(JsonDocument json);
-        
 
+
+        IEnumerable<PackageVersion> ConvertNpmJsonToPackageVersions(JsonDocument content, int maxVersionsCount);
+        IEnumerable<PackageVersion> ConvertNugetJsonToPackageVersions(JsonDocument content, int maxVersionsCount);
+        IEnumerable<PackageVersion> ConvertVsCodeJsonToPackageVersions(JsonDocument content, int maxVersionsCount);
     }
 }

--- a/Backend/PackageDownloader.Infrastructure/Services/Implementations/Docker/DockerPackageSearchService.cs
+++ b/Backend/PackageDownloader.Infrastructure/Services/Implementations/Docker/DockerPackageSearchService.cs
@@ -1,6 +1,8 @@
+using System.Text.Json;
 using PackageDownloader.Core.Models;
 using PackageDownloader.Core.Models.Docker;
 using PackageDownloader.Core.Services.Abstractions;
+using PackageDownloader.Infrastructure.Extensions;
 using PackageDownloader.Infrastructure.Services.Abstractions;
 
 namespace PackageDownloader.Infrastructure.Services.Implementations.Docker;
@@ -12,9 +14,11 @@ public class DockerPackageSearchService : IPackageSearchService
 {
     private readonly IDockerHubHttpClient _dockerHubClient;
 
-    public DockerPackageSearchService(IDockerHubHttpClient dockerHubClient)
+    private readonly IJsonPathExecutor _jsonPathExecutor;
+    public DockerPackageSearchService(IDockerHubHttpClient dockerHubClient, IJsonPathExecutor jsonPathExecutor)
     {
         _dockerHubClient = dockerHubClient;
+        _jsonPathExecutor = jsonPathExecutor;
     }
 
     public async Task<IEnumerable<PackageInfo>> SearchPackagesByName(string namePart)
@@ -102,5 +106,51 @@ public class DockerPackageSearchService : IPackageSearchService
             .Where(name => name.Contains(namePart, StringComparison.OrdinalIgnoreCase))
             .OrderBy(name => name.Length)
             .Take(10);
+    }
+
+    public async Task<IEnumerable<PackageVersion>> GetPackageVersions(string packageName, int maxVersionsCount)
+    {
+         ArgumentException.ThrowIfNullOrWhiteSpace(packageName);
+
+        const int pageSize = 100;
+
+        var parts = packageName.Split('/', 2);
+        string repository = parts.Length == 2 ? packageName : $"library/{packageName}";
+
+        var nextUri = new Uri(
+            $"https://hub.docker.com/v2/repositories/{repository}/tags" +
+            $"?page_size={pageSize}&ordering=last_updated");
+
+        var versions = new List<PackageVersion>();
+
+        while (nextUri is not null && versions.Count < maxVersionsCount)
+        {
+            using JsonDocument document = await nextUri.GetJsonContentAsync();
+
+            foreach (JsonElement node in _jsonPathExecutor.GetAllNodes(document.RootElement, "$.results[*]"))
+            {
+                string? tag = _jsonPathExecutor.GetSingleNode(node, "$.name")?.GetString();
+                if (string.IsNullOrEmpty(tag))
+                    continue;
+
+                long size = _jsonPathExecutor.GetSingleNode(node, "$.full_size") is { ValueKind: JsonValueKind.Number } sizeNode
+                    ? sizeNode.GetInt64()
+                    : 0;
+
+                versions.Add(new PackageVersion(tag, node.GetProperty("last_updated").GetDateTime()));
+
+                if (versions.Count >= maxVersionsCount)
+                    break;
+            }
+
+            string? next = _jsonPathExecutor.GetSingleNode(document.RootElement, "$.next") is
+                { ValueKind: JsonValueKind.String } nextNode
+                ? nextNode.GetString()
+                : null;
+
+            nextUri = next is null ? null : new Uri(next);
+        }
+
+        return versions.OrderByDescending(v => v.ReleaseDate);
     }
 }

--- a/Backend/PackageDownloader.Infrastructure/Services/Implementations/Other/JsonPathExecutor.cs
+++ b/Backend/PackageDownloader.Infrastructure/Services/Implementations/Other/JsonPathExecutor.cs
@@ -29,4 +29,8 @@ public class JsonPathExecutor : IJsonPathExecutor
        return result.ValueKind != JsonValueKind.Undefined  ? result : null;
     }
 
+    public JsonElement GetRequiredSingleNode(JsonElement rootElement, string jsonPath)
+    {
+        return GetSingleNode(rootElement, jsonPath) ?? throw new JsonException($"Expected single node at path {jsonPath}");
+    }
 }

--- a/Backend/PackageDownloader.Infrastructure/Services/Implementations/Other/PackageInfoConverterService.cs
+++ b/Backend/PackageDownloader.Infrastructure/Services/Implementations/Other/PackageInfoConverterService.cs
@@ -1,12 +1,13 @@
 ﻿using System.Text.Json;
 using JsonCons.JsonPath;
 using PackageDownloader.Core.Models;
+using PackageDownloader.Core.Services.Abstractions;
 using PackageDownloader.Infrastructure.Extensions;
 using PackageDownloader.Infrastructure.Services.Abstractions;
 
 namespace PackageDownloader.Infrastructure.Services.Implementations.Other
 {
-    public class PackageInfoConverterService (IJsonPathExecutor jPath) : IPackageInfoConverterService
+    public class PackageInfoConverterService(IJsonPathExecutor jPath) : IPackageInfoConverterService
     {
         private PackageInfo NpmConverter(JsonElement element)
         {
@@ -15,16 +16,18 @@ namespace PackageDownloader.Infrastructure.Services.Implementations.Other
             var packageElement = element.TryGetProperty("package", out var pkg) ? pkg : element;
 
             var repositoryUrl = "";
-            if (packageElement.TryGetProperty("links", out var links) && links.TryGetProperty("repository", out var repo))
+            if (packageElement.TryGetProperty("links", out var links) &&
+                links.TryGetProperty("repository", out var repo))
             {
                 repositoryUrl = repo.GetStringOrDefault();
-                repositoryUrl = repositoryUrl.StartsWith("git+") 
-                    ? repositoryUrl.Substring(4, repositoryUrl.Length - 4) 
+                repositoryUrl = repositoryUrl.StartsWith("git+")
+                    ? repositoryUrl.Substring(4, repositoryUrl.Length - 4)
                     : repositoryUrl;
             }
-             
+
             var npmUrl = "";
-            if (packageElement.TryGetProperty("links", out var linksForNpm) && linksForNpm.TryGetProperty("npm", out var npmLink))
+            if (packageElement.TryGetProperty("links", out var linksForNpm) &&
+                linksForNpm.TryGetProperty("npm", out var npmLink))
             {
                 npmUrl = npmLink.GetStringOrDefault();
             }
@@ -33,27 +36,28 @@ namespace PackageDownloader.Infrastructure.Services.Implementations.Other
                 var name = packageElement.GetProperty("name").GetStringOrDefault();
                 npmUrl = $"https://www.npmjs.com/package/{name}";
             }
-            
+
             string authors = "";
             if (packageElement.TryGetProperty("maintainers", out var maintainers))
             {
-                authors = string.Join(",", maintainers.EnumerateArray().Select(m => 
+                authors = string.Join(",", maintainers.EnumerateArray().Select(m =>
                     m.TryGetProperty("username", out var username) ? username.GetString() ?? "" : ""));
             }
-            else if (packageElement.TryGetProperty("publisher", out var publisher) && 
+            else if (packageElement.TryGetProperty("publisher", out var publisher) &&
                      publisher.TryGetProperty("username", out var publisherUsername))
             {
                 authors = publisherUsername.GetStringOrDefault();
             }
-            
+
             string packageLastVersion = packageElement.GetProperty("version").GetStringOrDefault();
-            
+
             long downloadsCount = 0;
-            if (element.TryGetProperty("downloads", out var downloads) && downloads.TryGetProperty("monthly", out var monthly))
+            if (element.TryGetProperty("downloads", out var downloads) &&
+                downloads.TryGetProperty("monthly", out var monthly))
             {
                 downloadsCount = monthly.GetInt64();
             }
-            
+
             PackageInfo packageInfo = new()
             {
                 Id = packageElement.GetProperty("name").GetStringOrDefault(),
@@ -73,14 +77,14 @@ namespace PackageDownloader.Infrastructure.Services.Implementations.Other
         private PackageInfo NugetConverter(JsonElement element)
         {
             string author = element.GetProperty("authors")
-                            .EnumerateArray()
-                            .FirstOrDefault()
-                            .GetStringOrDefault();
+                .EnumerateArray()
+                .FirstOrDefault()
+                .GetStringOrDefault();
 
             bool hasProjectUrl = element.TryGetProperty("projectUrl", out var projectUrl);
             bool hasIconUrl = element.TryGetProperty("iconUrl", out var iconUrl);
             string packageId = element.GetProperty("id").GetStringOrDefault();
-            
+
             PackageInfo packageInfo = new()
             {
                 Id = packageId,
@@ -99,29 +103,30 @@ namespace PackageDownloader.Infrastructure.Services.Implementations.Other
         }
 
         private readonly string _vsCodeLinkTemplate = "https://marketplace.visualstudio.com/items?itemName={0}.{1}";
+
         private PackageInfo VsCodeConverter(JsonElement element)
         {
-            
+
             string authorName = jPath.GetString(element, "$.publisher.displayName") ?? "";
             string authorId = jPath.GetString(element, "$.publisher.publisherName") ?? "";
 
             string sourceRepoLink = jPath.GetString(element,
                 "$.versions[0].properties[?(@.key=='Microsoft.VisualStudio.Services.Links.Source')].value") ?? "";
-            
+
             string iconUrl = jPath.GetString(element,
-                "$.versions[0].files[?(@.assetType=='Microsoft.VisualStudio.Services.Icons.Small')].source") ?? ""; 
-            
+                "$.versions[0].files[?(@.assetType=='Microsoft.VisualStudio.Services.Icons.Small')].source") ?? "";
+
             string packageName = jPath.GetString(element, "$.extensionName") ?? "";
             string packageId = $"{authorId}/{packageName}";
-            
-            string packageLastVersion =  jPath.GetString(element, "$.versions[0].version") ?? "";
-            
+
+            string packageLastVersion = jPath.GetString(element, "$.versions[0].version") ?? "";
+
             long downloadsCount = jPath.GetLong(element, "$.statistics[?(@.statisticName=='install')].value") ?? 0;
 
             string packageUrl = string.Format(_vsCodeLinkTemplate, authorId, packageName);
 
             string description = jPath.GetString(element, "$.shortDescription") ?? "";
-            
+
             PackageInfo packageInfo = new()
             {
                 Id = packageId,
@@ -138,15 +143,16 @@ namespace PackageDownloader.Infrastructure.Services.Implementations.Other
 
             return packageInfo;
         }
-        
-        private IEnumerable<T> ConvertModelFromJson<T>(JsonDocument data, Func<JsonElement, T> converter, string? arrayJsonPath = default)
+
+        private IEnumerable<T> ConvertModelFromJson<T>(JsonDocument data, Func<JsonElement, T> converter,
+            string? arrayJsonPath = default)
         {
-            var rootElements = arrayJsonPath != default 
+            var rootElements = arrayJsonPath != default
                 ? jPath.GetAllNodes(data.RootElement, arrayJsonPath)
                 : data.RootElement.EnumerateArray().ToList();
 
             return rootElements.Select(converter);
-            
+
         }
 
         public IEnumerable<PackageInfo> ConvertNpmJsonToPackageInfo(JsonDocument json)
@@ -169,19 +175,73 @@ namespace PackageDownloader.Infrastructure.Services.Implementations.Other
         {
             // NPM Registry API возвращает: {"objects": [{"package": {"name": "..."}, ...}, ...]}
             var objects = jPath.GetAllNodes(json.RootElement, "$.objects");
-            return objects.Select(obj => 
+            return objects.Select(obj =>
             {
-                if (obj.TryGetProperty("package", out var package) && 
+                if (obj.TryGetProperty("package", out var package) &&
                     package.TryGetProperty("name", out var name))
                 {
                     return name.GetString() ?? "";
                 }
+
                 return "";
             }).Where(name => !string.IsNullOrEmpty(name));
         }
 
         public IEnumerable<string> ConvertNugetJsonToSuggestionsList(JsonDocument json) =>
-           json.RootElement.GetStrings(arrayFieldName: "data");
-        
-    }
+            json.RootElement.GetStrings(arrayFieldName: "data");
+
+        public IEnumerable<PackageVersion> ConvertNpmJsonToPackageVersions(JsonDocument content, int maxVersionsCount)
+        {
+            HashSet<string> ignoreVersionsTags = ["created", "modified"];
+
+            return jPath.GetRequiredSingleNode(content.RootElement, "$.time")
+                .EnumerateObject()
+                .Select(time => new PackageVersion(time.Name, time.Value.GetDateTime()))
+                .Where(v => !ignoreVersionsTags.Contains(v.VersionTag))
+                .OrderByDescending(v => v.ReleaseDate)
+                .Take(maxVersionsCount);
+        }
+
+        public IEnumerable<PackageVersion> ConvertNugetJsonToPackageVersions(JsonDocument content, int maxVersionsCount)
+        {
+            return jPath
+                .GetAllNodes(content.RootElement, "$.items[*].items[*].catalogEntry")
+                .Select(node => new PackageVersion(
+                    node.GetProperty("version").GetStringOrDefault(),
+                    node.GetProperty("published").GetDateTime()
+                ))
+                .OrderByDescending(v => v.ReleaseDate)
+                .Take(maxVersionsCount);
+
+        }
+
+        public IEnumerable<PackageVersion> ConvertVsCodeJsonToPackageVersions(JsonDocument content,
+            int maxVersionsCount)
+        {
+            var versions = new List<PackageVersion>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (JsonElement node in jPath.GetAllNodes(
+                         content.RootElement, "$.results[0].extensions[0].versions[*]"))
+            {
+                string? version = jPath.GetSingleNode(node, "$.version")?.GetString();
+                if (string.IsNullOrEmpty(version))
+                    continue;
+
+                if (!seen.Add(version))
+                    continue;
+
+                DateTime lastUpdated =
+                    jPath.GetSingleNode(node, "$.lastUpdated") is { } updatedNode &&
+                    updatedNode.TryGetDateTime(out var parsed)
+                        ? parsed
+                        : DateTime.MinValue;
+
+
+                versions.Add(new PackageVersion(version, lastUpdated));
+            }
+
+            return versions.OrderByDescending(v => v.ReleaseDate).Take(maxVersionsCount);
+        }
+}   
 }

--- a/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageSearch/NpmPackageSearchService.cs
+++ b/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageSearch/NpmPackageSearchService.cs
@@ -9,6 +9,8 @@ public class NpmPackageSearchService(IPackageInfoConverterService packageInfoCon
 {
     // Используем официальное NPM Registry API вместо веб-интерфейса
     const string SearchPackageRequestUrl = "https://registry.npmjs.org/-/v1/search?text={0}&size=20";
+    
+    const string GetPackageDetailsUrl = "https://registry.npmjs.org/{0}";
 
     public async Task<IEnumerable<string>> GetPackagesNamesSuggestions(string namePart)
     {
@@ -17,6 +19,13 @@ public class NpmPackageSearchService(IPackageInfoConverterService packageInfoCon
         var content = await new Uri(url).GetJsonContentAsync();
 
         return packageInfoConverter.ConvertNpmJsonToSuggestionsList(content);  
+    }
+
+    public async Task<IEnumerable<PackageVersion>> GetPackageVersions(string packageName, int maxVersionsCount)
+    {
+        string url = string.Format(GetPackageDetailsUrl, packageName);
+        var content = await new Uri(url).GetJsonContentAsync();
+        return packageInfoConverter.ConvertNpmJsonToPackageVersions(content, maxVersionsCount);
     }
 
     public async Task<IEnumerable<PackageInfo>> SearchPackagesByName(string name)

--- a/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageSearch/NugetPackageSearchService.cs
+++ b/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageSearch/NugetPackageSearchService.cs
@@ -11,6 +11,8 @@ namespace PackageDownloader.Infrastructure.Services.Implementations.PackageSearc
 
         const string AutocompleteTemplateUrl = "https://azuresearch-ussc.nuget.org/autocomplete?q={0}";
 
+        private const string PackageDetailsTemplateUrl = "https://api.nuget.org/v3/registration5-semver1/{0}/index.json";
+        
         public async Task<IEnumerable<string>> GetPackagesNamesSuggestions(string namePart)
         {
             string url = string.Format(AutocompleteTemplateUrl, namePart);
@@ -18,6 +20,15 @@ namespace PackageDownloader.Infrastructure.Services.Implementations.PackageSearc
             var content = await new Uri(url).GetJsonContentAsync();
 
             return packageInfoConverter.ConvertNugetJsonToSuggestionsList(content);
+        }
+
+        public async Task<IEnumerable<PackageVersion>> GetPackageVersions(string packageName, int maxVersionsCount)
+        {
+            string url = string.Format(PackageDetailsTemplateUrl, packageName.ToLowerInvariant());
+            
+            var content = await new Uri(url).GetJsonContentAsync();
+
+            return packageInfoConverter.ConvertNugetJsonToPackageVersions(content, maxVersionsCount);
         }
 
         public async Task<IEnumerable<PackageInfo>> SearchPackagesByName(string name)

--- a/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageSearch/VsCodePackageSearchService.cs
+++ b/Backend/PackageDownloader.Infrastructure/Services/Implementations/PackageSearch/VsCodePackageSearchService.cs
@@ -1,4 +1,6 @@
-﻿using PackageDownloader.Core.Models;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using PackageDownloader.Core.Models;
 using PackageDownloader.Core.Services.Abstractions;
 using PackageDownloader.Infrastructure.Extensions;
 using PackageDownloader.Infrastructure.Services.Abstractions;
@@ -10,9 +12,48 @@ public class VsCodePackageSearchService (IPackageInfoConverterService packageInf
     const string SearchExtensionRequestUrl = "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery";
     private const string SearchVsCodeExtensionsPrePrompt = "vscode extension";
     
+    
     public async Task<IEnumerable<string>> GetPackagesNamesSuggestions(string namePart)
     {
         return await globalWebSearchService.GetSearchSuggestions(namePart, SearchVsCodeExtensionsPrePrompt);
+    }
+
+    public async Task<IEnumerable<PackageVersion>> GetPackageVersions(string packageName, int maxVersionsCount)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageName);
+
+        const int filterTypeExtensionName = 7;
+        const int filterTypeTarget = 8;
+        const int includeVersions = 0x1;
+        const int includeVersionProperties = 0x10;
+
+        var queryUri = new Uri(SearchExtensionRequestUrl);
+
+        var request = new
+        {
+            filters = new[]
+            {
+                new
+                {
+                    criteria = new[]
+                    {
+                        new { filterType = filterTypeExtensionName, value = packageName },
+                        new { filterType = filterTypeTarget, value = "Microsoft.VisualStudio.Code" }
+                    },
+                    pageNumber = 1,
+                    pageSize = 1
+                }
+            },
+            flags = includeVersions | includeVersionProperties
+        };
+
+        var headers = new Dictionary<string, string>
+        {
+            ["Accept"] = "application/json;api-version=3.0-preview.1"
+        };
+        
+        using JsonDocument content = await queryUri.PostJsonDataAsync(request, headers);
+        return packageInfoConverter.ConvertVsCodeJsonToPackageVersions(content, maxVersionsCount);
     }
 
     public async Task<IEnumerable<PackageInfo>> SearchPackagesByName(string name)
@@ -49,3 +90,16 @@ public class VsCodePackageSearchService (IPackageInfoConverterService packageInf
         return packageInfoConverter.ConvertVsCodeJsonToPackageInfo(jsonResult);
     }
 }
+
+internal sealed record GalleryQueryRequest(
+    [property: JsonPropertyName("filters")] GalleryFilter[] Filters,
+    [property: JsonPropertyName("flags")] int Flags);
+
+internal sealed record GalleryFilter(
+    [property: JsonPropertyName("criteria")] GalleryCriterion[] Criteria,
+    [property: JsonPropertyName("pageNumber")] int PageNumber,
+    [property: JsonPropertyName("pageSize")] int PageSize);
+
+internal sealed record GalleryCriterion(
+    [property: JsonPropertyName("filterType")] int FilterType,
+    [property: JsonPropertyName("value")] string Value);

--- a/Frontend/package-downloader-react/src/components/SearchForm/PackageSearchResult.test.tsx
+++ b/Frontend/package-downloader-react/src/components/SearchForm/PackageSearchResult.test.tsx
@@ -1,0 +1,75 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import PackageSearchResult from './PackageSearchResult';
+import {getPackageApiClient, PackageInfo, PackageType} from '../../services/apiClient';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({t: (key: string) => key}),
+}));
+
+vi.mock('../../services/apiClient', async (importOriginal) => ({
+    ...await importOriginal<typeof import('../../services/apiClient')>(),
+    getPackageApiClient: vi.fn(),
+}));
+
+vi.mock('../../stores/PackagesStore', () => ({
+    packagesSearchStore: {repositoryType: 'Docker'},
+}));
+
+vi.mock('../../stores/PackageInfoStore', () => ({
+    packageInfoStore: {fetchReadmeContent: vi.fn()},
+}));
+
+vi.mock('../../stores/NotificationStore', () => ({
+    notificationStore: {addError: vi.fn()},
+}));
+
+describe('PackageSearchResult version selector', () => {
+    const getPackageVersions = vi.fn();
+    const packageInfo = Object.assign(new PackageInfo(), {
+        id: 'postgres',
+        currentVersion: '17.5',
+        otherVersions: ['16.9'],
+        description: 'PostgreSQL',
+        tags: [],
+        authorInfo: 'PostgreSQL Global Development Group',
+        repositoryUrl: null,
+        iconUrl: null,
+        packageUrl: null,
+        downloadsCount: 100,
+        isAddedInCart: false,
+        defaultIcon: '/icons/box.svg',
+        getPackageIconOrStockImage: () => '/icons/box.svg',
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        getPackageVersions.mockResolvedValue([
+            {versionTag: '17.5', releaseDate: null},
+            {versionTag: '16.9', releaseDate: null},
+        ]);
+        vi.mocked(getPackageApiClient).mockResolvedValue({
+            getPackageVersions,
+        } as unknown as Awaited<ReturnType<typeof getPackageApiClient>>);
+    });
+
+    it('loads the expanded version list only when the selector is opened', async () => {
+        const user = userEvent.setup();
+        render(<PackageSearchResult packageInfo={packageInfo}/>);
+
+        expect(getPackageVersions).not.toHaveBeenCalled();
+        expect(screen.getByRole('combobox')).toHaveTextContent('17.5');
+
+        await user.click(screen.getByRole('combobox'));
+
+        expect(await screen.findByRole('option', {name: '16.9'})).toBeInTheDocument();
+        expect(getPackageVersions).toHaveBeenCalledWith(PackageType.Docker, 'postgres');
+
+        await user.keyboard('{Escape}');
+        await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+        await user.click(screen.getByRole('combobox'));
+
+        expect(getPackageVersions).toHaveBeenCalledTimes(1);
+    });
+});

--- a/Frontend/package-downloader-react/src/components/SearchForm/PackageSearchResult.tsx
+++ b/Frontend/package-downloader-react/src/components/SearchForm/PackageSearchResult.tsx
@@ -12,18 +12,19 @@ import {
     Select,
     MenuItem,
     FormControl,
+    CircularProgress,
 } from "@mui/material";
-import {PackageInfo} from "../../services/apiClient";
+import {getPackageApiClient, PackageInfo} from "../../services/apiClient";
 import {cartStore} from "../../stores/CartStore";
 import DownloadIcon from '@mui/icons-material/Download'; // Импортируем иконку загрузки
 import {Add, GitHub, LibraryBooks, Public} from "@mui/icons-material";
 import {packagesSearchStore} from "../../stores/PackagesStore";
-import {compareVersions} from "../../utils/versionsComparer";
 import {useState} from "react";
 import {useTranslation} from "react-i18next";
 import {packageInfoStore} from "../../stores/PackageInfoStore.ts";
 import {sideNavigationStore} from "../../stores/SideNavigationStore.ts";
 import {AdditionalPanel} from "../SideNavigationLayout/PanelsContext/additionalPanel.ts";
+import {notificationStore} from "../../stores/NotificationStore.ts";
 
 interface PackageSearchResultsProps {
     packageInfo: PackageInfo;
@@ -40,7 +41,6 @@ const PackageSearchResult: React.FC<PackageSearchResultsProps> = ({
                                                                           tags,
                                                                           repositoryUrl,
                                                                           packageUrl,
-                                                                          otherVersions,
                                                                           isAddedInCart,
                                                                           defaultIcon
                                                                       }
@@ -49,10 +49,35 @@ const PackageSearchResult: React.FC<PackageSearchResultsProps> = ({
     const {t} = useTranslation();
 
     const [selectedVersion, setSelectedVersion] = useState<string>(currentVersion);
+    const [versions, setVersions] = useState<string[]>([currentVersion]);
+    const [areVersionsLoading, setAreVersionsLoading] = useState(false);
+    const [areVersionsLoaded, setAreVersionsLoaded] = useState(false);
 
     const {fetchReadmeContent} = packageInfoStore;
 
     const {repositoryType} = packagesSearchStore;
+
+    const loadVersions = async () => {
+        if (areVersionsLoaded || areVersionsLoading) {
+            return;
+        }
+
+        setAreVersionsLoading(true);
+        try {
+            const {getPackageVersions} = await getPackageApiClient();
+            const packageVersions = await getPackageVersions(repositoryType, id);
+            setVersions(Array.from(new Set([
+                currentVersion,
+                ...packageVersions.map(({versionTag}) => versionTag).filter(Boolean),
+            ])));
+            setAreVersionsLoaded(true);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            notificationStore.addError(`${t("ErrorOccurred")}: ${message}`);
+        } finally {
+            setAreVersionsLoading(false);
+        }
+    };
 
     return (
         <Card variant="outlined">
@@ -132,19 +157,19 @@ const PackageSearchResult: React.FC<PackageSearchResultsProps> = ({
                             <Select
                                 value={selectedVersion}
                                 onChange={(e) => setSelectedVersion(e.target.value)}
+                                onOpen={() => void loadVersions()}
                             >
-                                <MenuItem key={id + currentVersion} value={currentVersion}>
-                                    {currentVersion}
-                                </MenuItem>
-                                {otherVersions && otherVersions.length > 0 &&
-                                    otherVersions
-                                        .filter(ver => ver !== currentVersion)
-                                        .sort((a, b) => compareVersions(a, b, "DESC"))
-                                        .map((ver) => (
-                                            <MenuItem key={id + ver} value={ver}>
-                                                {ver}
-                                            </MenuItem>
-                                        ))}
+                                {versions.map((version) => (
+                                    <MenuItem key={id + version} value={version}>
+                                        {version}
+                                    </MenuItem>
+                                ))}
+                                {areVersionsLoading && (
+                                    <MenuItem disabled>
+                                        <CircularProgress size={18} sx={{mr: 1}}/>
+                                        {t("LoadingData")}
+                                    </MenuItem>
+                                )}
                             </Select>
                         </FormControl>
                         {!isAddedInCart && (

--- a/Frontend/package-downloader-react/src/components/SearchForm/SearchResultsList.tsx
+++ b/Frontend/package-downloader-react/src/components/SearchForm/SearchResultsList.tsx
@@ -32,8 +32,8 @@ const SearchResults: React.FC<ISearchResultsProps> = memo(({fondedPackages, isSe
                 gridTemplateColumns: 'repeat(auto-fill, minmax(350px, 1fr))',
                 gap: 2
             }}>
-                {fondedPackages.map((packageInfo, index) => (
-                    <Grid item key={index}>
+                {fondedPackages.map((packageInfo) => (
+                    <Grid item key={packageInfo.id}>
                         <Card variant="outlined">
                             <CardContent>
                                 <PackageSearchResult packageInfo={packageInfo}/>

--- a/Frontend/package-downloader-react/src/services/apiClient.ts
+++ b/Frontend/package-downloader-react/src/services/apiClient.ts
@@ -55,6 +55,27 @@ export class PackagesAPIClient {
     };
 
     /**
+     * Returns package versions ordered by the package repository.
+     */
+    getPackageVersions = async (
+        packageType: PackageType,
+        packageName: string,
+        maxVersionsCount = 40,
+    ): Promise<PackageVersion[]> => {
+        const response: AxiosResponse<PackageVersion[]> = await this.http.get(
+            "/api/PackageInfo/GetPackageVersions",
+            {
+                params: {
+                    packageType,
+                    packageName,
+                    maxVersionsCount,
+                },
+            },
+        );
+        return response.data;
+    };
+
+    /**
      * @param body (optional)
      * @return Success
      */
@@ -167,6 +188,11 @@ export interface PackageRecommendation {
     id: string;
     choiceDescription: string;
     codeExample: string;
+}
+
+export interface PackageVersion {
+    versionTag: string;
+    releaseDate: string | null;
 }
 
 export interface PackageRequest {


### PR DESCRIPTION
# Добавить получение версий пакета и ленивую загрузку списка версий

## Что сделано

Добавлен отдельный API-метод для получения расширенного списка версий пакета и реализована его ленивая загрузка в карточках результатов поиска.

Поисковый запрос по-прежнему определяет выбранную по умолчанию актуальную версию. Полный список версий загружается только тогда, когда пользователь впервые открывает выпадающий список.

## Backend

### Новый API-метод

Добавлен endpoint:

```http
GET /api/PackageInfo/GetPackageVersions
```

Параметры:

| Параметр | Тип | Описание |
|---|---|---|
| `packageType` | `PackageType` | Тип репозитория: `Npm`, `Nuget`, `VsCode` или `Docker` |
| `packageName` | `string` | Идентификатор пакета |
| `maxVersionsCount` | `int` | Максимальное количество версий, по умолчанию `40` |

Пример:

```http
GET /api/PackageInfo/GetPackageVersions?packageType=Docker&packageName=postgres&maxVersionsCount=40
```

Формат ответа:

```json
[
  {
    "versionTag": "17.5",
    "releaseDate": "2026-07-15T10:30:00Z"
  },
  {
    "versionTag": "16.9",
    "releaseDate": "2026-06-20T08:00:00Z"
  }
]
```

Дата публикации может быть `null`, если источник не предоставил её.

### Получение версий из репозиториев

| Тип пакета | Источник | Особенности |
|---|---|---|
| npm | npm Registry API | Версии извлекаются из `time`, служебные поля `created` и `modified` исключаются |
| NuGet | NuGet Registration API | Используются `catalogEntry.version` и `catalogEntry.published` |
| VS Code | Visual Studio Marketplace Gallery API | Запрашиваются версии расширения, дубликаты удаляются без учёта регистра |
| Docker | Docker Hub API | Поддерживаются официальные образы через namespace `library`, пользовательские репозитории и пагинация тегов |

Версии сортируются по дате публикации или обновления в убывающем порядке и ограничиваются значением `maxVersionsCount`.

### Изменения сервисного слоя

- В `IPackageSearchService` добавлен метод `GetPackageVersions`.
- Добавлена модель `PackageVersion` с тегом версии и датой публикации.
- Реализация получения версий добавлена для npm, NuGet, VS Code и Docker.
- В `IPackageInfoConverterService` добавлены преобразователи версий для разных форматов API.
- В JSONPath-исполнитель добавлен `GetRequiredSingleNode`, выбрасывающий `JsonException`, если обязательный узел отсутствует.
- Выполнен сопутствующий рефакторинг `PackageInfoConverterService`.

## Frontend

### Ленивая загрузка версий

В карточке результата поиска изменена работа селектора версий:

1. Изначально выбранной и доступной остаётся `currentVersion`, полученная вместе с результатами поиска.
2. До открытия селектора дополнительный API-запрос не выполняется.
3. При первом открытии вызывается `GetPackageVersions`.
4. Во время запроса внутри списка отображается индикатор загрузки.
5. Полученные версии объединяются с текущей версией, пустые значения и дубликаты исключаются.
6. После успешной загрузки список сохраняется в состоянии карточки, поэтому повторные открытия не создают дополнительных запросов.
7. В случае ошибки показывается уведомление, а следующее открытие селектора повторяет загрузку.

### API-клиент

В `PackagesAPIClient` добавлен метод:

```ts
getPackageVersions(
    packageType: PackageType,
    packageName: string,
    maxVersionsCount = 40,
): Promise<PackageVersion[]>
```

Также добавлен TypeScript-интерфейс `PackageVersion`.

### Стабильность состояния карточек

Ключ результата поиска изменён с индекса массива на `packageInfo.id`. Это предотвращает перенос выбранной версии и загруженного списка между разными пакетами при обновлении результатов поиска.

## Тестирование

Добавлен unit-тест для селектора версий, который проверяет:

- отсутствие запроса до открытия списка;
- сохранение текущей версии по умолчанию;
- загрузку расширенного списка после открытия;
- передачу правильного типа и имени пакета;
- отсутствие повторного запроса после успешной загрузки.

Выполнены проверки:

- `dotnet build PackageDownloader.sln --no-restore` — успешно, 0 предупреждений и 0 ошибок;
- `npm run build` — успешно;
- `npm run test:run` — успешно, 122 теста;
- ESLint для изменённых frontend-файлов — успешно.

## Обратная совместимость

- Существующие методы поиска и подсказок не изменены.
- Формат поискового ответа остаётся совместимым.
- Выбранная по умолчанию версия по-прежнему берётся из `currentVersion`.
- Новый API-метод является дополнительным и не влияет на существующие клиенты.
